### PR TITLE
Removing deprecation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,12 @@ functions:
       TAGFUNCTION: Tag Value
 ```
 
+### 4) Delete stack 
+
+```bash
+go run mage.go remove 
+```
+
 ## Author
 
 👤 **Matheus Fidelis**

--- a/configs/dev.yml
+++ b/configs/dev.yml
@@ -1,4 +1,4 @@
 ENV: dev
-REGION: ${self:custom.region}
+REGION: 'us-east-1'
 DYNAMO_TABLE_BOOKS: ${self:custom.dynamo-books-name}
 SQS_QUEUE_BOOKS: ${self:custom.sqs-books-name}

--- a/magefile.go
+++ b/magefile.go
@@ -1,3 +1,4 @@
+//go:build mage
 // +build mage
 
 package main
@@ -12,7 +13,7 @@ import (
 var Default = PHONY
 
 func PHONY() {
-	mg.Deps(Clean, Build, Deploy)
+	mg.Deps(Clean, Build, Deploy, Remove)
 }
 
 // clean remove all bin
@@ -57,4 +58,9 @@ func Test() error {
 func Deploy() error {
 	mg.Deps(Clean, Build)
 	return sh.Run("serverless", "deploy", "--verbose", "--force")
+}
+
+func Remove() error {
+	mg.Deps(Clean)
+	return sh.Run("serverless", "remove")
 }

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,6 +1,6 @@
 service: serverless-go
 
-frameworkVersion: '>=1.28.0 <2.0.0'
+# frameworkVersion: '>=1.28.0 <2.0.0'
 
 provider:
   name: aws
@@ -38,20 +38,19 @@ provider:
       - sqs:SendMessage
     Resource: arn:aws:sqs:*:*:*
 
-  package:
-    exclude:
-      - ./**
-      - .git/**
-      - .vscode/**
-      - .test/**
-    include:
-      - ./bin/**
+  # package:
+  #   exclude:
+  #     - ./**
+  #     - .git/**
+  #     - .vscode/**
+  #     - .test/**
+  #   include:
+  #     - ./bin/**
 
   environment:
     ${file(./configs/${self:provider.stage}.yml)}
 
 custom:
-  region: ${self:provider.region}
   stage:  ${opt:stage, self:provider.stage}
   prefix: ${self:custom.stage}-${self:service}
   dynamo-books-name: ${self:custom.prefix}-books-catalog

--- a/serverless.yml
+++ b/serverless.yml
@@ -38,15 +38,6 @@ provider:
       - sqs:SendMessage
     Resource: arn:aws:sqs:*:*:*
 
-  # package:
-  #   exclude:
-  #     - ./**
-  #     - .git/**
-  #     - .vscode/**
-  #     - .test/**
-  #   include:
-  #     - ./bin/**
-
   environment:
     ${file(./configs/${self:provider.stage}.yml)}
 


### PR DESCRIPTION
Upgrade boilerplate to latest version for Serverless Framework 
Update serverless.yml to avoid deprecation warnings 
Mage / Magefile examples 
Removing Commando `go run mage.go remove` 